### PR TITLE
Fix .clear() method

### DIFF
--- a/pyconfigatron/__init__.py
+++ b/pyconfigatron/__init__.py
@@ -65,7 +65,7 @@ class ConfigStore(object):
         self._config_tree.locked = value
 
     def clear(self):
-        self.attributes.clear()
+        self._attributes.clear()
 
     def update_dict(self, d):
         for key, value in d.iteritems():


### PR DESCRIPTION
Previously, when doing `set_env`, it would look for a config setting called `attributes`